### PR TITLE
New serializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.13.1-R0.1-SNAPSHOT</version>
+			<version>1.13.2-R0.1-SNAPSHOT</version>
 			<type>jar</type>
 			<scope>provided</scope>
 		</dependency>

--- a/src/net/slipcor/pvparena/arena/ArenaClass.java
+++ b/src/net/slipcor/pvparena/arena/ArenaClass.java
@@ -3,7 +3,6 @@ package net.slipcor.pvparena.arena;
 import net.slipcor.pvparena.PVPArena;
 import net.slipcor.pvparena.classes.PABlockLocation;
 import net.slipcor.pvparena.core.Debug;
-import net.slipcor.pvparena.core.StringParser;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Chest;
@@ -12,12 +11,13 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.inventory.meta.SpawnEggMeta;
 import org.bukkit.plugin.IllegalPluginAccessException;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+
+import static net.slipcor.pvparena.core.ItemStackUtils.getItemStacksFromConfig;
 
 /**
  * <pre>Arena Class class</pre>
@@ -127,16 +127,17 @@ public final class ArenaClass {
             ItemStack[] armors;
 
             try {
-                items = cfg.getConfigurationSection("classes").getConfigurationSection(className)
-                        .getList("items").toArray(new ItemStack[0]);
-                offHand = cfg.getConfigurationSection("classes").getConfigurationSection(className)
-                        .getList("items").toArray(new ItemStack[0])[0];
-                armors = cfg.getConfigurationSection("classes").getConfigurationSection(className)
-                        .getList("items").toArray(new ItemStack[0]);
+                items = getItemStacksFromConfig(cfg.getConfigurationSection("classes").getConfigurationSection(className)
+                        .getList("items"));
+                offHand = getItemStacksFromConfig(cfg.getConfigurationSection("classes").getConfigurationSection(className)
+                        .getList("items"))[0];
+                armors = getItemStacksFromConfig(cfg.getConfigurationSection("classes").getConfigurationSection(className)
+                        .getList("items"));
             } catch (final Exception e) {
                 Bukkit.getLogger().severe(
                         "[PVP Arena] Error while parsing class, skipping: "
                                 + className);
+                e.printStackTrace();
                 continue;
             }
             final String classChest;

--- a/src/net/slipcor/pvparena/commands/PAA_Class.java
+++ b/src/net/slipcor/pvparena/commands/PAA_Class.java
@@ -8,7 +8,6 @@ import net.slipcor.pvparena.core.Help;
 import net.slipcor.pvparena.core.Help.HELP;
 import net.slipcor.pvparena.core.Language;
 import net.slipcor.pvparena.core.Language.MSG;
-import net.slipcor.pvparena.core.StringParser;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -16,6 +15,8 @@ import org.bukkit.inventory.ItemStack;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static net.slipcor.pvparena.core.Utils.getSerializableItemStacks;
 
 /**
  * <pre>
@@ -69,9 +70,9 @@ public class PAA_Class extends AbstractArenaCommand {
             final Player player = (Player) sender;
             final List<ItemStack> items = new ArrayList<>();
 
-            arena.getArenaConfig().setManually("classitems." + args[1] + ".items", player.getInventory().getStorageContents());
-            arena.getArenaConfig().setManually("classitems." + args[1] + ".offhand", new ItemStack[]{player.getInventory().getItemInOffHand()});
-            arena.getArenaConfig().setManually("classitems." + args[1] + ".armor", player.getInventory().getArmorContents());
+            arena.getArenaConfig().setManually("classitems." + args[1] + ".items", getSerializableItemStacks(player.getInventory().getStorageContents()));
+            arena.getArenaConfig().setManually("classitems." + args[1] + ".offhand", getSerializableItemStacks(player.getInventory().getItemInOffHand()));
+            arena.getArenaConfig().setManually("classitems." + args[1] + ".armor", getSerializableItemStacks(player.getInventory().getArmorContents()));
             arena.getArenaConfig().save();
 
             arena.addClass(args[1], player.getInventory().getStorageContents(), player.getInventory().getItemInOffHand(), player.getInventory().getArmorContents());

--- a/src/net/slipcor/pvparena/commands/PAA_PlayerClass.java
+++ b/src/net/slipcor/pvparena/commands/PAA_PlayerClass.java
@@ -7,14 +7,13 @@ import net.slipcor.pvparena.core.Help;
 import net.slipcor.pvparena.core.Help.HELP;
 import net.slipcor.pvparena.core.Language;
 import net.slipcor.pvparena.core.Language.MSG;
-import net.slipcor.pvparena.core.StringParser;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static net.slipcor.pvparena.core.Utils.getSerializableItemStacks;
 
 /**
  * <pre>
@@ -67,9 +66,9 @@ public class PAA_PlayerClass extends AbstractArenaCommand {
 
         if ("save".equalsIgnoreCase(args[0])) {
 
-            arena.getArenaConfig().setManually("classitems." + className + ".items", player.getInventory().getStorageContents());
-            arena.getArenaConfig().setManually("classitems." + className + ".offhand", new ItemStack[]{player.getInventory().getItemInOffHand()});
-            arena.getArenaConfig().setManually("classitems." + className + ".armor", player.getInventory().getArmorContents());
+            arena.getArenaConfig().setManually("classitems." + className + ".items", getSerializableItemStacks(player.getInventory().getStorageContents()));
+            arena.getArenaConfig().setManually("classitems." + className + ".offhand",  getSerializableItemStacks(player.getInventory().getItemInOffHand()));
+            arena.getArenaConfig().setManually("classitems." + className + ".armor", getSerializableItemStacks(player.getInventory().getArmorContents()));
             arena.getArenaConfig().save();
 
             arena.addClass(className, player.getInventory().getStorageContents(), player.getInventory().getItemInOffHand(), player.getInventory().getArmorContents());

--- a/src/net/slipcor/pvparena/core/Config.java
+++ b/src/net/slipcor/pvparena/core/Config.java
@@ -20,6 +20,9 @@ import org.bukkit.inventory.ItemStack;
 import java.io.File;
 import java.util.*;
 
+import static net.slipcor.pvparena.core.ItemStackUtils.getItemStacksFromConfig;
+import static net.slipcor.pvparena.core.Utils.getSerializableItemStacks;
+
 /**
  * <pre>
  * Configuration class
@@ -462,7 +465,7 @@ public class Config {
 
         CFG(final String node, final ItemStack[] value, final boolean multiple, final String source) {
             this.node = node;
-            this.value = value;
+            this.value = getSerializableItemStacks(value);
             type = multiple ? "items" : "material";
             module = source;
         }
@@ -761,13 +764,13 @@ public class Config {
         final String path = cfg.getNode();
         try {
             String test = this.cfg.getString(path);
-            if ("none".equals(test)) {
+            if ("none".equalsIgnoreCase(test)) {
                 return new ItemStack[0];
             }
         } catch (Exception e) {
         }
         try {
-            return this.cfg.getList(path).toArray(new ItemStack[0]);
+            return getItemStacksFromConfig(this.cfg.getList(path));
         } catch (NullPointerException e) {
             return new ItemStack[0];
         }

--- a/src/net/slipcor/pvparena/core/ItemStackUtils.java
+++ b/src/net/slipcor/pvparena/core/ItemStackUtils.java
@@ -1,0 +1,146 @@
+package net.slipcor.pvparena.core;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+
+import java.util.*;
+
+import static org.bukkit.configuration.serialization.ConfigurationSerialization.deserializeObject;
+
+public class ItemStackUtils  {
+    /**
+     * List of "meta-type" config keys which can be drop
+     */
+    private enum HandledMetaType {
+        POTION, ENCHANTED, BOOK_SIGNED, BOOK, BANNER, MAP, FIREWORK, LEATHER_ARMOR, UNSPECIFIC
+    }
+
+    private static boolean isAnHandledMetaType(String metaTypeString) {
+        try{
+            HandledMetaType.valueOf(metaTypeString);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Check the meta keyset to deduce which meta-type is associated
+     * @param keySet The meta config node values
+     * @return Right "meta-type" value
+     */
+    private static HandledMetaType getRightMetaType(Collection<String> keySet) {
+        if(keySet.contains("potion-type")) {
+            return HandledMetaType.POTION;
+        }
+        if(keySet.contains("stored-enchants")) {
+            return HandledMetaType.ENCHANTED;
+        }
+        if(keySet.contains("map-id")) {
+            return HandledMetaType.MAP;
+        }
+        if(keySet.contains("patterns")) {
+            return HandledMetaType.BANNER;
+        }
+        if(keySet.contains("pages")) {
+            if(keySet.contains("author")) {
+                return HandledMetaType.BOOK_SIGNED;
+            }
+            return HandledMetaType.BOOK;
+        }
+        if(keySet.contains("firework-effects")) {
+            return HandledMetaType.FIREWORK;
+        }
+        if(keySet.contains("color")) {
+            return HandledMetaType.LEATHER_ARMOR;
+        }
+        return HandledMetaType.UNSPECIFIC;
+    }
+
+
+    /**
+     * Pseudo-serializer which creates a map version of objects in order to prettify the yaml after serialization
+     * @param itemStack A bukkit ItemStack object
+     * @return Serializable map
+     */
+    public static Map<String, Object> getItemStackMap(ItemStack itemStack) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("type", itemStack.getType().name());
+        if (itemStack.getAmount() != 1) {
+            result.put("amount", itemStack.getAmount());
+        }
+
+        ItemMeta meta = itemStack.getItemMeta();
+        if (!Bukkit.getItemFactory().equals(meta, null)) {
+            Map<String, Object> metaMap = new LinkedHashMap<>(meta.serialize());
+            if(isAnHandledMetaType(metaMap.get("meta-type").toString())) {
+                metaMap.remove("meta-type");
+
+                if(meta instanceof LeatherArmorMeta) {
+                    metaMap.put("color", ((LeatherArmorMeta) meta).getColor().serialize());
+                }
+            }
+            result.put("meta", metaMap);
+        }
+
+        return result;
+    }
+
+    /**
+     * A custom deserializer which convert prettified yaml config to bukkit objects
+     * Mainly based on the bukkit ConfigurationSerializable deserializer
+     * @param args An ItemStack config node
+     * @return A bukkit ItemStack object
+     */
+    private static ItemStack deserialize(Map<String, Object> args) {
+        int amount = 1;
+
+        Material type = Material.getMaterial((String) args.get("type"));
+
+        if (args.containsKey("amount")) {
+            amount = ((Number) args.get("amount")).intValue();
+        }
+
+        ItemStack result = new ItemStack(type, amount);
+
+        if (args.containsKey("meta")) {
+            Map<String, Object> metaMap = new LinkedHashMap<>((Map<String, Object>) args.get("meta"));
+            metaMap.put("==", ItemMeta.class.getSimpleName());
+            if(!metaMap.containsKey("meta-type")) {
+                metaMap.put("meta-type", getRightMetaType(metaMap.keySet()).name());
+
+                //Simplify Leather Armour colors
+                if(metaMap.containsKey("color")) {
+                    Color color = Color.deserialize((Map<String, Object>) metaMap.get("color"));
+                    metaMap.put("color", color);
+                }
+            }
+
+
+            ConfigurationSerializable raw = deserializeObject(metaMap);
+            if (raw instanceof ItemMeta) {
+                result.setItemMeta((ItemMeta) raw);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Deserialize an ItemSTack list config node
+     * @param mapList List of ItemStack nodes
+     * @return An array of bukkit ItemStack objects
+     */
+    public static ItemStack[] getItemStacksFromConfig(List<?> mapList) {
+        ItemStack[] result = new ItemStack[mapList.size()];
+        for(int i = 0; i < mapList.size(); i++) {
+            result[i] = deserialize((Map<String, Object>) mapList.get(i));
+        }
+        return result;
+    }
+}

--- a/src/net/slipcor/pvparena/core/Utils.java
+++ b/src/net/slipcor/pvparena/core/Utils.java
@@ -4,16 +4,37 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static net.slipcor.pvparena.core.ItemStackUtils.getItemStackMap;
+
 public final class Utils {
     private Utils() {
     }
 
-    public static ItemStack[] getItemStacksFromMaterials(Material... mats) {
-        ItemStack[] result = new ItemStack[mats.length];
-        for (int i=0; i< mats.length; i++) {
-            result[i] = new ItemStack(mats[i], mats[i]==Material.ARROW?64:1);
+    public static List<Map<String, Object>> getItemStacksFromMaterials(Material... mats) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        for(Material mat : mats) {
+            result.add(getItemStackMap(new ItemStack(mat, mat == Material.ARROW ? 64 : 1)));
         }
         return result;
+    }
+
+
+    public static List<Map<String, Object>> getSerializableItemStacks(ItemStack[] itemStacks) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        for(ItemStack itemStack : itemStacks) {
+            if(itemStack != null) {
+                result.add(getItemStackMap(itemStack));
+            }
+        }
+        return result;
+    }
+
+    public static List<Map<String, Object>> getSerializableItemStacks(ItemStack itemStack) {
+        return getSerializableItemStacks(new ItemStack[]{itemStack});
     }
 
     public static Material getWoolMaterialFromChatColor(final ChatColor color) {

--- a/src/net/slipcor/pvparena/managers/ConfigurationManager.java
+++ b/src/net/slipcor/pvparena/managers/ConfigurationManager.java
@@ -11,7 +11,6 @@ import net.slipcor.pvparena.core.Config;
 import net.slipcor.pvparena.core.Config.CFG;
 import net.slipcor.pvparena.core.Language;
 import net.slipcor.pvparena.core.Language.MSG;
-import net.slipcor.pvparena.core.StringParser;
 import net.slipcor.pvparena.core.Utils;
 import net.slipcor.pvparena.loadables.ArenaGoal;
 import net.slipcor.pvparena.loadables.ArenaModule;
@@ -24,6 +23,8 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.*;
+
+import static net.slipcor.pvparena.core.ItemStackUtils.getItemStacksFromConfig;
 
 /**
  * <pre>
@@ -201,13 +202,14 @@ public final class ConfigurationManager {
             ItemStack[] armors = new ItemStack[]{new ItemStack(Material.AIR, 1)};
 
             try {
-                items = config.getList("classitems."+stringObjectEntry1.getKey()+".items").toArray(new ItemStack[0]);
-                offHand = config.getList("classitems."+stringObjectEntry1.getKey()+".offhand").toArray(new ItemStack[]{new ItemStack(Material.AIR, 1)})[0];
-                armors = config.getList("classitems."+stringObjectEntry1.getKey()+".armor").toArray(new ItemStack[0]);
+                items = getItemStacksFromConfig(config.getList("classitems."+stringObjectEntry1.getKey()+".items"));
+                offHand = getItemStacksFromConfig(config.getList("classitems."+stringObjectEntry1.getKey()+".offhand"))[0];
+                armors = getItemStacksFromConfig(config.getList("classitems."+stringObjectEntry1.getKey()+".armor"));
             } catch (final Exception e) {
                 Bukkit.getLogger().severe(
                         "[PVP Arena] Error while parsing class, skipping: "
                                 + stringObjectEntry1.getKey());
+                        arena.getDebugger().i(e.getMessage());
                 continue;
             }
             try {


### PR DESCRIPTION
Hello,

in order to solve the issue https://github.com/slipcor/pvparena/issues/357 I developed an new serializer which is more human readable. Currently I just applied it to inventories but I think it is reusable for ChestFiller. The code reuses the bukkit serialization system as far as possible an I tried to prepare next developments of the bukkit API with a list of item "meta informations" compatible with the serializer.
Advanced meta data for fireworks and banners are not managed by my serializer, they use the bukkit one.